### PR TITLE
use explicit resampling algorithms in create_tile_map.py

### DIFF
--- a/src/opera_disp_tms/create_tile_map.py
+++ b/src/opera_disp_tms/create_tile_map.py
@@ -18,16 +18,17 @@ def create_tile_map(output_folder: str, input_rasters: list[str]):
         input_rasters: List of gdal-compatible raster paths to mosaic
     """
     with tempfile.NamedTemporaryFile() as mosaic_vrt, tempfile.NamedTemporaryFile() as byte_vrt:
-        # mosaic input rasters
-        gdal.BuildVRT(mosaic_vrt.name, input_rasters)
+        # mosaic the input rasters
+        gdal.BuildVRT(mosaic_vrt.name, input_rasters, resampleAlg='nearest')
 
-        # scale mosaic from Float to Byte
+        # scale the mosaic from Float to Byte
         gdal.Translate(
             destName=byte_vrt.name,
             srcDS=mosaic_vrt.name,
             format='VRT',
             outputType=gdalconst.GDT_Byte,
             scaleParams=[[]],
+            resampleAlg='nearest',
         )
 
         # create tile map
@@ -37,6 +38,7 @@ def create_tile_map(output_folder: str, input_rasters: list[str]):
             '--zoom=2-11',
             f'--processes={multiprocessing.cpu_count()}',
             '--webviewer=openlayers',
+            '--resampling=near',
             byte_vrt.name,
             output_folder,
         ]


### PR DESCRIPTION
Previously each command was using it's default (nearest neighbor for BuildVRT/Translate, average for gdal2tiles). Now we explicitly use the same method (nearest neighbor) at each step.

Nearest neighbor is appreciably faster than average, and at a glance I don't see an appreciable difference in the output imagery.