### PR TITLE
calculate true min/max data values in create_tile_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.1.1]
 ### Changed
 * Calculate true minimum/maximum data values in `create_tile_map` to avoid extreme displacement values being set to
-  NoData
+  NoData. Fixes [#8](https://github.com/ASFHyP3/OPERA-DISP-TMS/issues/8).
 
 ## [0.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1]
+### Changed
+* Calculate true minimum/maximum data values in `create_tile_map` to avoid extreme displacement values being set to
+  NoData
+
 ## [0.1.0]
 ### Added
 * Utility for creating a test dataset using [Global Coherence Dataset](https://registry.opendata.aws/ebd-sentinel-1-global-coherence-backscatter/)

--- a/src/opera_disp_tms/create_tile_map.py
+++ b/src/opera_disp_tms/create_tile_map.py
@@ -22,12 +22,13 @@ def create_tile_map(output_folder: str, input_rasters: list[str]):
         gdal.BuildVRT(mosaic_vrt.name, input_rasters, resampleAlg='nearest')
 
         # scale the mosaic from Float to Byte
+        stats = gdal.Info(mosaic_vrt.name, stats=True, format='json')['bands'][0]['metadata']['']
         gdal.Translate(
             destName=byte_vrt.name,
             srcDS=mosaic_vrt.name,
             format='VRT',
             outputType=gdalconst.GDT_Byte,
-            scaleParams=[[]],
+            scaleParams=[[stats['STATISTICS_MINIMUM'], stats['STATISTICS_MAXIMUM']]],
             resampleAlg='nearest',
         )
 


### PR DESCRIPTION
New descending tile map generated with this code is at https://asj-dev.s3.amazonaws.com/opera-disp/nodata/openlayers.html

Compared to the old descending tile map generated from v0.1.0 at https://asj-dev.s3.amazonaws.com/opera-disp/california/desc/2017/Q3-4/openlayers.html