### PR TITLE
Change frame naming input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3]
+### Changed
+* `generate_frame_tile.py` now only takes the upper left corner as input to create a 1 
+
 ## [0.1.2]
 ### Added
 * Bounds of the mosaic created in `create_tile_map.py` are written to a json file in tile folder

--- a/README.md
+++ b/README.md
@@ -43,11 +43,9 @@ These tiles serve as the foundation for the creation of all other Tile Map Serve
 
 The `generate_frame_tile` CLI command can be used to generate a frame metadata tile:
 ```bash
-generate_frame_tile -125 41 -124 42 ascending
+generate_frame_tile -125 42 ascending
 ```
-Where `-125 41 -124 42` is a desired bounding box in **integer** `minx, miny, max, maxy` longitude/latitude values, and `ascending` specifies which orbit direction you want to generate a frame metadata tile for (`ascending` or `descending`).
-
-For TMS generation ASF will be using 1x1 degree tiles.
+Where `-125 42` is the upper left corner of the desired 1 by 1 grid bounding box in **integer** `minx maxy` longitude/latitude values in WGS84 projection, and `ascending` specifies which orbit direction you want to generate a frame metadata tile for (`ascending` or `descending`).
 
 The resulting products have the name format:
 `METADATA_{orbit direction}_{upper left corner in lon/lat}.tif`.

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -13,7 +13,6 @@ from opera_disp_tms.frames import Frame, intersect
 from opera_disp_tms.s3_xarray import get_opera_disp_granule_metadata
 from opera_disp_tms.utils import validate_bbox
 
-
 gdal.UseExceptions()
 
 
@@ -275,7 +274,7 @@ def create_tile_for_bbox(upper_left_corner: Iterable[int], direction: str) -> Pa
     Returns:
         The path to the frame metadata tile
     """
-    bbox = [upper_left_corner[0] + 1, upper_left_corner[1] - 1, upper_left_corner[0], upper_left_corner[1]]
+    bbox = [upper_left_corner[0], upper_left_corner[1] - 1, upper_left_corner[0], upper_left_corner[1] - 1]
     direction = direction.upper()
     if direction not in ['ASCENDING', 'DESCENDING']:
         raise ValueError('Direction must be either "ASCENDING" or "DESCENDING"')

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -264,16 +264,18 @@ def create_metadata_tile(bbox: Iterable[int], frames: Iterable[Frame], tile_path
     tile_ds = None
 
 
-def create_tile_for_bbox(bbox: Iterable[int], direction: str) -> Path:
+def create_tile_for_bbox(upper_left_corner: Iterable[int], direction: str) -> Path:
     """Create the frame metadata tile for a specific bounding box
 
     Args:
-        bbox: The bounding box to create the frame for in the (minx, miny, maxx, maxy) in EPSG:4326, integers only.
+        upper_left_corner: Coordinates of the upper left corner of the bounding box in EPSG 4326
         direction: The direction of the orbit pass ('ascending' or 'descending')
+
 
     Returns:
         The path to the frame metadata tile
     """
+    bbox = [upper_left_corner[0] - 1, upper_left_corner[1] - 1, upper_left_corner[0], upper_left_corner[1]]
     direction = direction.upper()
     if direction not in ['ASCENDING', 'DESCENDING']:
         raise ValueError('Direction must be either "ASCENDING" or "DESCENDING"')
@@ -287,10 +289,11 @@ def create_tile_for_bbox(bbox: Iterable[int], direction: str) -> Path:
 
 def main():
     """CLI entry point
-    Example: generate_frame_tile -125 41 -124 42 ascending
+    Example: generate_frame_tile -124 42 ascending
     """
     parser = argparse.ArgumentParser(description='Create a frame metadata tile for a given bounding box')
-    parser.add_argument('bbox', type=int, nargs=4, help='Bounding box in the form of min_lon min_lat max_lon max_lat')
+    parser.add_argument('bbox', type=int, nargs=2, help='Upper left coordinate (max_lon max_lat) in EPSG: 4326 to '
+                                                        'create a 1x1 bounding box')
     parser.add_argument('direction', type=str, choices=['ascending', 'descending'], help='Direction of the orbit pass')
     args = parser.parse_args()
     create_tile_for_bbox(args.bbox, direction=args.direction)

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -275,7 +275,7 @@ def create_tile_for_bbox(upper_left_corner: Iterable[int], direction: str) -> Pa
     Returns:
         The path to the frame metadata tile
     """
-    bbox = [upper_left_corner[0] - 1, upper_left_corner[1] - 1, upper_left_corner[0], upper_left_corner[1]]
+    bbox = [upper_left_corner[0] + 1, upper_left_corner[1] - 1, upper_left_corner[0], upper_left_corner[1]]
     direction = direction.upper()
     if direction not in ['ASCENDING', 'DESCENDING']:
         raise ValueError('Direction must be either "ASCENDING" or "DESCENDING"')

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -263,18 +263,17 @@ def create_metadata_tile(bbox: Iterable[int], frames: Iterable[Frame], tile_path
     tile_ds = None
 
 
-def create_tile_for_bbox(upper_left_corner: Iterable[int], direction: str) -> Path:
-    """Create the frame metadata tile for a specific bounding box
+def create_tile_for_bbox(bbox: Iterable[int], direction: str) -> Path:
+    """Create the frame metadata tile for
 
     Args:
-        upper_left_corner: Coordinates of the upper left corner of the bounding box in EPSG 4326
+        bbox: The bounding box to create the frame for in the form (minx, miny, maxx, maxy) in EPSG 4326, integers only
         direction: The direction of the orbit pass ('ascending' or 'descending')
 
 
     Returns:
         The path to the frame metadata tile
     """
-    bbox = [upper_left_corner[0], upper_left_corner[1] - 1, upper_left_corner[0] + 1, upper_left_corner[1]]
     direction = direction.upper()
     if direction not in ['ASCENDING', 'DESCENDING']:
         raise ValueError('Direction must be either "ASCENDING" or "DESCENDING"')
@@ -295,7 +294,9 @@ def main():
                                                                      'EPSG: 4326 to create a 1x1 bounding box')
     parser.add_argument('direction', type=str, choices=['ascending', 'descending'], help='Direction of the orbit pass')
     args = parser.parse_args()
-    create_tile_for_bbox(args.upper_left_corner, direction=args.direction)
+    bbox = [args.upper_left_corner[0], args.upper_left_corner[1] - 1,
+            args.upper_left_corner[0] + 1, args.upper_left_corner[1]]
+    create_tile_for_bbox(bbox, direction=args.direction)
 
 
 if __name__ == '__main__':

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -274,7 +274,7 @@ def create_tile_for_bbox(upper_left_corner: Iterable[int], direction: str) -> Pa
     Returns:
         The path to the frame metadata tile
     """
-    bbox = [upper_left_corner[0], upper_left_corner[1] - 1, upper_left_corner[0], upper_left_corner[1] - 1]
+    bbox = [upper_left_corner[0], upper_left_corner[1] - 1, upper_left_corner[0] + 1, upper_left_corner[1]]
     direction = direction.upper()
     if direction not in ['ASCENDING', 'DESCENDING']:
         raise ValueError('Direction must be either "ASCENDING" or "DESCENDING"')

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -291,11 +291,11 @@ def main():
     Example: generate_frame_tile -124 42 ascending
     """
     parser = argparse.ArgumentParser(description='Create a frame metadata tile for a given bounding box')
-    parser.add_argument('bbox', type=int, nargs=2, help='Upper left coordinate (max_lon max_lat) in EPSG: 4326 to '
-                                                        'create a 1x1 bounding box')
+    parser.add_argument('upper_left_corner', type=int, nargs=2, help='Upper left coordinate (max_lon max_lat) in '
+                                                                     'EPSG: 4326 to create a 1x1 bounding box')
     parser.add_argument('direction', type=str, choices=['ascending', 'descending'], help='Direction of the orbit pass')
     args = parser.parse_args()
-    create_tile_for_bbox(args.bbox, direction=args.direction)
+    create_tile_for_bbox(args.upper_left_corner, direction=args.direction)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of taking a bounding box as in put for `generate_frame_tile.py`, user will enter the upper left coordinate in EPSG:4326