### PR TITLE
Fix gaps between relative orbits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [0.2.0]
 ### Changed
 * metadata tile script name from `generate_frame_tile.py` to `generate_metadata_tile.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3]
+### Changed
+* Frame ordering strategy so that west most relative orbits are on top for ascending data, and on the bottom for descending data
+
 ## [0.1.2]
 ### Added
 * Bounds of the mosaic created in `create_tile_map.py` are written to a json file in tile folder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.3]
+## [0.2.0]
 ### Changed
 * Frame ordering strategy so that west most relative orbits are on top for ascending data, and on the bottom for descending data
+
+### Fixed
+* Removal of empty metadata tile is now conditional on the tile being all nodata, not the absence of granules
 
 ## [0.1.2]
 ### Added

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -85,16 +85,14 @@ def reorder_frames(frame_list: Iterable[Frame], add_first: str) -> List[Frame]:
     for orbit in orbits:
         frames = [frame for frame in frame_list if frame.relative_orbit_number == orbit]
         frames = sorted(frames, key=lambda x: x.frame_id, reverse=True)
-
         if add_first == 'min_frame_number':
             sort_metric = max([x.frame_id for x in frames])
         elif add_first in ['east_most', 'west_most']:
-            sort_metric = max([x.geom.bounds[3] for x in frames])
+            sort_metric = min([x.geom.bounds[0] for x in frames])
         else:
             raise ValueError('Invalid order_by parameter. Use "min_frame_number", "east_most", or "west_most.')
-
         orbit_groups[orbit] = (sort_metric, frames)
-
+    
     reverse = add_first in ['east_most', 'min_frame_number']
     sorted_orbits = sorted(orbit_groups, key=lambda x: orbit_groups[x][0], reverse=reverse)
     sorted_frames = [orbit_groups[orbit][1] for orbit in sorted_orbits]
@@ -282,7 +280,7 @@ def create_tile_for_bbox(bbox: Iterable[int], direction: str) -> Path:
     relevant_frames = intersect(bbox=bbox, orbit_pass=direction, is_north_america=True, is_land=True)
     updated_frames = [buffer_frame_geometry(x) for x in relevant_frames]
     # This ordering minimizes orbit-edge gaps in tilesets by prioritizing IW1 over IW3 data
-    order_by = 'west_most' if direction == 'ASCENDING' else 'east_most'
+    order_by = 'east_most' if direction == 'ASCENDING' else 'west_most'
     ordered_frames = reorder_frames(updated_frames, add_first=order_by)
     create_metadata_tile(bbox, ordered_frames, out_path)
     return out_path

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -87,15 +87,13 @@ def reorder_frames(frame_list: Iterable[Frame], add_first: str) -> List[Frame]:
         frames = sorted(frames, key=lambda x: x.frame_id, reverse=True)
 
         if add_first == 'min_frame_number':
-            metric = max([x.frame_id for x in frames])
-        elif add_first == 'east_most':
-            metric = max([x.geom.bounds[3] for x in frames])
-        elif add_first == 'west_most':
-            metric = min([x.geom.bounds[0] for x in frames])
+            sort_metric = max([x.frame_id for x in frames])
+        elif add_first in ['east_most', 'west_most']:
+            sort_metric = max([x.geom.bounds[3] for x in frames])
         else:
             raise ValueError('Invalid order_by parameter. Use "min_frame_number", "east_most", or "west_most.')
 
-        orbit_groups[orbit] = (metric, frames)
+        orbit_groups[orbit] = (sort_metric, frames)
 
     reverse = add_first in ['east_most', 'min_frame_number']
     sorted_orbits = sorted(orbit_groups, key=lambda x: orbit_groups[x][0], reverse=reverse)

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -284,7 +284,7 @@ def create_tile_for_bbox(bbox: Iterable[int], direction: str) -> Path:
     relevant_frames = intersect(bbox=bbox, orbit_pass=direction, is_north_america=True, is_land=True)
     updated_frames = [buffer_frame_geometry(x) for x in relevant_frames]
     # This ordering minimizes orbit-edge gaps in tilesets by prioritizing IW1 over IW3 data
-    order_by = 'east_most' if direction == 'ASCENDING' else 'west_most'
+    order_by = 'west_most' if direction == 'ASCENDING' else 'east_most'
     ordered_frames = reorder_frames(updated_frames, add_first=order_by)
     create_metadata_tile(bbox, ordered_frames, out_path)
     return out_path

--- a/src/opera_disp_tms/generate_frame_tile.py
+++ b/src/opera_disp_tms/generate_frame_tile.py
@@ -65,14 +65,14 @@ def buffer_frame_geometry(frame: Frame, buffer_size_in_meters: int = -3500) -> F
     return frame
 
 
-def reorder_frames(frame_list: Iterable[Frame], order_by: str = 'west_most') -> List[Frame]:
+def reorder_frames(frame_list: Iterable[Frame], add_first: str) -> List[Frame]:
     """Reorder a set of frames so that they overlap correctly when rasterized.
     Frames within a relative orbit are stacked so that higher frame numbers are on top (so they are rasterized first).
-    Relative orbits sets are orderd by either frame number, or from west to east.
+    Relative orbits sets are orderd by either frame number, from west to east, or from east to west.
 
     Args:
         frame_list: The list of frames to reorder
-        order_by: Strategy to use when ordering relative orbit sets (`frame_number`, or `west_most`)
+        add_first: Strategy to use when ordering relative orbit sets ("min_frame_number", "east_most", "west_most")
 
     Returns:
         The reordered list of frames
@@ -86,16 +86,19 @@ def reorder_frames(frame_list: Iterable[Frame], order_by: str = 'west_most') -> 
         frames = [frame for frame in frame_list if frame.relative_orbit_number == orbit]
         frames = sorted(frames, key=lambda x: x.frame_id, reverse=True)
 
-        if order_by == 'frame_number':
+        if add_first == 'min_frame_number':
             metric = max([x.frame_id for x in frames])
-        elif order_by == 'west_most':
-            metric = max([x.geom.bounds[0] for x in frames])
+        elif add_first == 'east_most':
+            metric = max([x.geom.bounds[3] for x in frames])
+        elif add_first == 'west_most':
+            metric = min([x.geom.bounds[0] for x in frames])
         else:
-            raise ValueError('Invalid order_by parameter. Please use "frame_number" or "west_most".')
+            raise ValueError('Invalid order_by parameter. Use "min_frame_number", "east_most", or "west_most.')
 
         orbit_groups[orbit] = (metric, frames)
 
-    sorted_orbits = sorted(orbit_groups, key=lambda x: orbit_groups[x][0], reverse=True)
+    reverse = add_first in ['east_most', 'min_frame_number']
+    sorted_orbits = sorted(orbit_groups, key=lambda x: orbit_groups[x][0], reverse=reverse)
     sorted_frames = [orbit_groups[orbit][1] for orbit in sorted_orbits]
     sorted_frames = [frame for sublist in sorted_frames for frame in sublist]
     return sorted_frames
@@ -280,7 +283,9 @@ def create_tile_for_bbox(bbox: Iterable[int], direction: str) -> Path:
     out_path = Path(create_product_name(['metadata'], direction, bbox) + '.tif')
     relevant_frames = intersect(bbox=bbox, orbit_pass=direction, is_north_america=True, is_land=True)
     updated_frames = [buffer_frame_geometry(x) for x in relevant_frames]
-    ordered_frames = reorder_frames(updated_frames)
+    # This ordering minimizes orbit-edge gaps in tilesets by prioritizing IW1 over IW3 data
+    order_by = 'east_most' if direction == 'ASCENDING' else 'west_most'
+    ordered_frames = reorder_frames(updated_frames, add_first=order_by)
     create_metadata_tile(bbox, ordered_frames, out_path)
     return out_path
 

--- a/tests/test_generate_frame_tile.py
+++ b/tests/test_generate_frame_tile.py
@@ -29,25 +29,28 @@ def test_reorder_frames():
     frame_asc = StubFrame(1, 1, Geom([0, 0, 1, 1]), 'ASC')
     frame_des = StubFrame(1, 1, Geom([0, 0, 1, 1]), 'DES')
     with pytest.raises(ValueError):
-        generate_frame_tile.reorder_frames([frame_asc, frame_des])
+        generate_frame_tile.reorder_frames([frame_asc, frame_des], add_first='min_frame_number')
 
-    frame_1_1 = StubFrame(1, 1, Geom([1, 1, 2, 2]), 'ASC')
-    frame_1_2 = StubFrame(1, 2, Geom([3, 3, 4, 4]), 'ASC')
+    frame_1_1 = StubFrame(1, 1, Geom([2, 1, 4, 3]), 'ASC')
+    frame_1_2 = StubFrame(1, 2, Geom([4, 3, 6, 5]), 'ASC')
     frame_2_3 = StubFrame(2, 3, Geom([0, 0, 2, 2]), 'ASC')
-    frame_2_4 = StubFrame(2, 4, Geom([2, 2, 3, 3]), 'ASC')
+    frame_2_4 = StubFrame(2, 4, Geom([2, 2, 4, 4]), 'ASC')
 
-    result = generate_frame_tile.reorder_frames([frame_2_4, frame_1_2, frame_2_3, frame_1_1], order_by='frame_number')
+    result = generate_frame_tile.reorder_frames(
+        [frame_2_4, frame_1_2, frame_2_3, frame_1_1], add_first='min_frame_number'
+    )
     assert result == [frame_2_4, frame_2_3, frame_1_2, frame_1_1]
 
-    result = generate_frame_tile.reorder_frames([frame_2_4, frame_1_2, frame_2_3, frame_1_1], order_by='west_most')
+    result = generate_frame_tile.reorder_frames([frame_2_4, frame_1_2, frame_2_3, frame_1_1], add_first='west_most')
+    assert result == [frame_2_4, frame_2_3, frame_1_2, frame_1_1]
+
+    result = generate_frame_tile.reorder_frames([frame_2_4, frame_1_2, frame_2_3, frame_1_1], add_first='east_most')
     assert result == [frame_1_2, frame_1_1, frame_2_4, frame_2_3]
 
     frame_1_anti = StubFrame(1, 1, Geom([-1, -1, 1, 1]), 'ASC')
     frame_2_norm = StubFrame(2, 1, Geom([0, 0, 2, 2]), 'ASC')
-    assert generate_frame_tile.reorder_frames([frame_1_anti, frame_2_norm], order_by='west_most') == [
-        frame_2_norm,
-        frame_1_anti,
-    ]
+    result = generate_frame_tile.reorder_frames([frame_1_anti, frame_2_norm], add_first='east_most')
+    assert result == [frame_2_norm, frame_1_anti]
 
 
 def test_create_empty_tile_frame(tmp_path):
@@ -78,7 +81,7 @@ def test_burn_frame(tmp_path):
     ds = None
 
     golden = np.zeros(data.shape)
-    golden[int(data.shape[0] / 2):, :] = 9999
+    golden[int(data.shape[0] / 2) :, :] = 9999
     assert np.all(data == golden)
 
     frame2 = Frame(10000, 1, 1, 'ASCENDING', 1, 1, box(1, 1, 1.5, 2))

--- a/tests/test_generate_frame_tile.py
+++ b/tests/test_generate_frame_tile.py
@@ -81,7 +81,7 @@ def test_burn_frame(tmp_path):
     ds = None
 
     golden = np.zeros(data.shape)
-    golden[int(data.shape[0] / 2) :, :] = 9999
+    golden[int(data.shape[0] / 2):, :] = 9999
     assert np.all(data == golden)
 
     frame2 = Frame(10000, 1, 1, 'ASCENDING', 1, 1, box(1, 1, 1.5, 2))


### PR DESCRIPTION
By stacking the west-most orbits on top for ascending data (and the reverse for descending data) we can remove many of the no data gaps that were present in the tilesets due to Sentinel-1 layover/shadow.