### PR TITLE
fix extent.json writing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 * Ability to generate SW Disp velocity tiles
 
+### Fixed
+* `extent.json` will be written during `create_tile_map.py` even if the directory `tiles/` does not exist prior to running
+
 ## [0.2.0]
 ### Added
 * Python scripts for generating California SW Disp tileset

--- a/src/opera_disp_tms/create_tile_map.py
+++ b/src/opera_disp_tms/create_tile_map.py
@@ -46,9 +46,6 @@ def create_tile_map(output_folder: str, input_rasters: list[str], scale_range: L
         vrt_info = gdal.Info(mosaic_vrt.name, stats=True, format='json')
         stats = vrt_info['bands'][0]['metadata']['']
 
-        # get bounds of VRT and write to file
-        get_tile_extent(vrt_info, Path(output_folder))
-
         if scale_range is None:
             scale_range = [stats['STATISTICS_MINIMUM'], stats['STATISTICS_MAXIMUM']]
 
@@ -73,6 +70,9 @@ def create_tile_map(output_folder: str, input_rasters: list[str], scale_range: L
             output_folder,
         ]
         subprocess.run(command)
+
+        # get bounds of VRT and write to file
+        get_tile_extent(vrt_info, Path(output_folder))
 
 
 def main():


### PR DESCRIPTION
Switch the order of commands in `create_tile_map.py`, so the output folder is definitely created before writing extent.json. 