### PR TITLE
tag all uploaded files as products, drop hyp3lib dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - pytest
   - pytest-console-scripts
   - pytest-cov
+  - responses
   # For Running
   - gdal
   - boto3
@@ -24,7 +25,6 @@ dependencies:
   - pyproj
   - h5py
   - h5netcdf
-  - hyp3lib
   - xarray
   - rioxarray
   - numba

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ Documentation = "https://github.com/ASFHyP3/opera-disp-tms/tree/develop?tab=read
 generate_metadata_tile = "opera_disp_tms.generate_metadata_tile:main"
 generate_sw_disp_tile = "opera_disp_tms.generate_sw_disp_tile:main"
 generate_sw_vel_tile = "opera_disp_tms.generate_sw_vel_tile:main"
-get_tmp_s3_creds = "opera_disp_tms.tmp_s3_access:main"
 create_tile_map = "opera_disp_tms.create_tile_map:main"
 
 [project.entry-points.hyp3]

--- a/src/opera_disp_tms/__main__.py
+++ b/src/opera_disp_tms/__main__.py
@@ -3,11 +3,8 @@ OPERA-DISP Tile Map Service Generator
 """
 
 import argparse
-import os
 import sys
 from importlib.metadata import entry_points
-
-from hyp3lib.fetch import write_credentials_to_netrc_file
 
 
 def main():
@@ -23,11 +20,6 @@ def main():
         help='Select the HyP3 entrypoint to use',  # HyP3 entrypoints are specified in `pyproject.toml`
     )
     args, unknowns = parser.parse_known_args()
-
-    username = os.getenv('EARTHDATA_USERNAME')
-    password = os.getenv('EARTHDATA_PASSWORD')
-    if username and password:
-        write_credentials_to_netrc_file(username, password, domain='uat.urs.earthdata.nasa.gov', append=False)
 
     # NOTE: Cast to set because of: https://github.com/pypa/setuptools/issues/3649
     (process_entry_point,) = set(entry_points(group='hyp3', name=args.process))

--- a/src/opera_disp_tms/tmp_s3_access.py
+++ b/src/opera_disp_tms/tmp_s3_access.py
@@ -1,4 +1,4 @@
-import argparse
+import os
 
 import cachetools.func
 import requests
@@ -9,44 +9,24 @@ import s3fs
 # For instance, 50 minutes so that credentials are refreshed at least 10 minutes
 # before they're set to expire.
 @cachetools.func.ttl_cache(ttl=60 * 50)
-def get_temporary_aws_credentials(endpoint: str = 'https://cumulus-test.asf.alaska.edu/s3credentials') -> dict:
+def get_temporary_aws_credentials() -> dict:
     """Gets temporary AWS S3 access credentials from the cache or requests new credentials if credentials are expired.
-
-    Args:
-        endpoint: TEA URL to request temporary credentials from
+       Assumes Earthdata Login credentials are available via a .netrc file or via EARTHDATA_USERNAME and
+       EARTHDATA_PASSWORD environment variables.
 
     Returns:
         dictionary of credentials
     """
-    resp = requests.get(endpoint)
+    resp = requests.get('https://cumulus-test.asf.alaska.edu/s3credentials')
+    if resp.status_code == 401 and resp.url.startswith('https://uat.urs.earthdata.nasa.gov/oauth/authorize?'):
+        auth = (os.environ['EARTHDATA_USERNAME'], os.environ['EARTHDATA_PASSWORD'])
+        resp = requests.get(resp.url, auth=auth)
     resp.raise_for_status()
     return resp.json()
 
 
 @cachetools.func.ttl_cache(ttl=60 * 50)
-def get_temporary_s3_fs(endpoint: str = 'https://cumulus-test.asf.alaska.edu/s3credentials') -> s3fs.S3FileSystem:
-    creds = get_temporary_aws_credentials(endpoint=endpoint)
+def get_temporary_s3_fs() -> s3fs.S3FileSystem:
+    creds = get_temporary_aws_credentials()
     s3_fs = s3fs.S3FileSystem(key=creds['accessKeyId'], secret=creds['secretAccessKey'], token=creds['sessionToken'])
     return s3_fs
-
-
-def main():
-    """CLI entry point for getting temporary S3 credentials
-    Example: get_tmp_s3_creds --endpoint https://cumulus-test.asf.alaska.edu/s3credentials
-    """
-    parser = argparse.ArgumentParser(description='Get temporary S3 credentials')
-    parser.add_argument(
-        '--endpoint',
-        default='https://cumulus-test.asf.alaska.edu/s3credentials',
-        help='URL to request temporary credentials from',
-    )
-    args = parser.parse_args()
-    credentials = get_temporary_aws_credentials(args.endpoint)
-    print('Run these commands in your terminal to set up your temporary AWS Credentials:\n')
-    print(f'export AWS_ACCESS_KEY_ID={credentials["accessKeyId"]}')
-    print(f'export AWS_SECRET_ACCESS_KEY={credentials["secretAccessKey"]}')
-    print(f'export AWS_SESSION_TOKEN={credentials["sessionToken"]}')
-
-
-if __name__ == '__main__':
-    main()

--- a/src/opera_disp_tms/utils.py
+++ b/src/opera_disp_tms/utils.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timedelta
 from mimetypes import guess_type
 from pathlib import Path
@@ -175,7 +176,7 @@ def upload_dir_to_s3(path_to_dir: Path, bucket: str, prefix: str = ''):
         bucket: S3 bucket to which the directory should be uploaded
         prefix: prefix in S3 bucket to upload the directory to. Defaults to ''
     """
-    for branch in path_to_dir.walk():
+    for branch in os.walk(path_to_dir, topdown=True):
         for filename in branch[2]:
             path_to_file = Path(branch[0]) / filename
             key = str(prefix / path_to_file.relative_to(path_to_dir))

--- a/src/opera_disp_tms/utils.py
+++ b/src/opera_disp_tms/utils.py
@@ -164,6 +164,7 @@ def upload_file_to_s3(path_to_file: Path, bucket: str, key):
     extra_args = {'ContentType': guess_type(path_to_file)[0]}
     S3_CLIENT.upload_file(str(path_to_file), bucket, key, ExtraArgs=extra_args)
 
+    # tag files as 'product' so hyp3 doesn't treat the .png files as browse images
     tag_set = {'TagSet': [{'Key': 'file_type', 'Value': 'product'}]}
     S3_CLIENT.put_object_tagging(Bucket=bucket, Key=key, Tagging=tag_set)
 

--- a/src/opera_disp_tms/utils.py
+++ b/src/opera_disp_tms/utils.py
@@ -1,16 +1,17 @@
-import os
 from datetime import datetime, timedelta
+from mimetypes import guess_type
 from pathlib import Path
 from typing import Iterable, Tuple, Union
 
+import boto3
 import requests
-from hyp3lib.aws import upload_file_to_s3
 from osgeo import gdal, osr
 from pyproj import Transformer
 
 
 gdal.UseExceptions()
 
+S3_CLIENT = boto3.client('s3')
 DATE_FORMAT = '%Y%m%dT%H%M%SZ'
 
 
@@ -158,6 +159,14 @@ def create_tile_name(
     return name
 
 
+def upload_file_to_s3(path_to_file: Path, bucket: str, key):
+    extra_args = {'ContentType': guess_type(path_to_file)[0]}
+    S3_CLIENT.upload_file(str(path_to_file), bucket, key, ExtraArgs=extra_args)
+
+    tag_set = {'TagSet': [{'Key': 'file_type', 'Value': 'product'}]}
+    S3_CLIENT.put_object_tagging(Bucket=bucket, Key=key, Tagging=tag_set)
+
+
 def upload_dir_to_s3(path_to_dir: Path, bucket: str, prefix: str = ''):
     """Upload a local directory, subdirectory, and all contents to an S3 bucket
 
@@ -166,8 +175,8 @@ def upload_dir_to_s3(path_to_dir: Path, bucket: str, prefix: str = ''):
         bucket: S3 bucket to which the directory should be uploaded
         prefix: prefix in S3 bucket to upload the directory to. Defaults to ''
     """
-    for branch in os.walk(path_to_dir, topdown=True):
+    for branch in path_to_dir.walk():
         for filename in branch[2]:
             path_to_file = Path(branch[0]) / filename
-            file_prefix = str(prefix / path_to_file.relative_to(path_to_dir).parent)
-            upload_file_to_s3(path_to_file, bucket, file_prefix)
+            key = str(prefix / path_to_file.relative_to(path_to_dir))
+            upload_file_to_s3(path_to_file, bucket, key)

--- a/tests/test_tmp_s3_access.py
+++ b/tests/test_tmp_s3_access.py
@@ -1,0 +1,37 @@
+import responses
+
+import opera_disp_tms.tmp_s3_access as tmp_s3_access
+
+
+@responses.activate
+def test_get_temporary_aws_credentials():
+    responses.get(
+        'https://cumulus-test.asf.alaska.edu/s3credentials',
+        status=200,
+        json={'foo': 'bar'},
+    )
+
+    assert tmp_s3_access.get_temporary_aws_credentials() == {'foo': 'bar'}
+
+
+@responses.activate
+def test_get_temporary_aws_credentials_env(monkeypatch):
+    monkeypatch.setenv('EARTHDATA_USERNAME', 'user')
+    monkeypatch.setenv('EARTHDATA_PASSWORD', 'pass')
+    responses.get(
+        'https://cumulus-test.asf.alaska.edu/s3credentials',
+        status=301,
+        headers={'Location': 'https://uat.urs.earthdata.nasa.gov/oauth/authorize?foo=bar'},
+    )
+    responses.get(
+        'https://uat.urs.earthdata.nasa.gov/oauth/authorize',
+        status=401,
+    )
+    responses.get(
+        'https://uat.urs.earthdata.nasa.gov/oauth/authorize',
+        match=[responses.matchers.header_matcher({'Authorization': 'Basic dXNlcjpwYXNz'})],
+        status=200,
+        json={'foo': 'bar'},
+    )
+
+    assert tmp_s3_access.get_temporary_aws_credentials() == {'foo': 'bar'}


### PR DESCRIPTION
- re-implements hyp3lib.upload_file_to_s3 allowing all files to be uploaded with `file_type=product`
- refactors `get_temporary_aws_credentials()` to fall back on environment variables when .netrc authentication fails, eliminating the dependency on `hyp3lib.fetch.write_credentials_to_netrc_file`
- removes hyp3lib from environment.yml
- removes cli interface for `tmp_s3_credentials.py`