### PR TITLE
update search.py for v0.9 data delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `get_orbit_pass` for using OPERA frame DB for getting a frame's orbit direction
 
 ### Changed
-* Revised `search.py` to query all v0.9+ granules in CMR UAT, rather than California-specific v0.7 granules
+* Revised `search.py` to query all v0.7+ granules in CMR UAT, rather than California-specific v0.7 granules
 * The [`static-analysis`](.github/workflows/static-analysis.yml) Github Actions workflow now uses `ruff` rather than `flake8` for linting.
 
 ## [0.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1]
+### Changed
+* Revised `search.py` to query all v0.9+ granules in CMR UAT, rather than California-specific v0.7 granules
+
 ## [0.4.0]
 ### Added
 * Ability to update the reference date for OPERA DISP granule xarray objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.1]
+### Added
+* `get_orbit_pass` for using OPERA frame DB for getting a frame's orbit direction
+
 ### Changed
 * Revised `search.py` to query all v0.9+ granules in CMR UAT, rather than California-specific v0.7 granules
 

--- a/src/opera_disp_tms/frames.py
+++ b/src/opera_disp_tms/frames.py
@@ -170,3 +170,31 @@ def intersect(
 
     intersecting_frames = [Frame.from_row(row) for row in rows]
     return intersecting_frames
+
+
+def get_orbit_pass(frame_id: int) -> str:
+    """Get the orbit pass for an OPERA frame
+
+    Args:
+        frame_id: OPERA frame ID to get orbit pass for
+
+    Returns:
+        ASCENDING or DESCENDING
+    """
+    download_frame_db()
+    query = (
+        'SELECT fid as frame_id, epsg, relative_orbit_number, orbit_pass, '
+        '       is_land, is_north_america, ASText(GeomFromGPB(geom)) AS wkt '
+        'FROM frames '
+        'WHERE fid = ?'
+    )
+    with sqlite3.connect(DB_PATH) as con:
+        con.enable_load_extension(True)
+        con.load_extension('mod_spatialite')
+        cursor = con.cursor()
+        cursor.execute(query, [int(frame_id)])
+        rows = cursor.fetchall()
+
+    assert len(rows) == 1
+    frame = Frame.from_row(rows[0])
+    return frame.orbit_pass

--- a/src/opera_disp_tms/frames.py
+++ b/src/opera_disp_tms/frames.py
@@ -172,6 +172,7 @@ def intersect(
     return intersecting_frames
 
 
+# FIXME: Remove when updating to OPERA DISP data v0.9
 def get_orbit_pass(frame_id: int) -> str:
     """Get the orbit pass for an OPERA frame
 
@@ -179,7 +180,7 @@ def get_orbit_pass(frame_id: int) -> str:
         frame_id: OPERA frame ID to get orbit pass for
 
     Returns:
-        ASCENDING or DESCENDING
+        "ASCENDING" or "DESCENDING"
     """
     download_frame_db()
     query = (

--- a/src/opera_disp_tms/generate_metadata_tile.py
+++ b/src/opera_disp_tms/generate_metadata_tile.py
@@ -10,7 +10,7 @@ from shapely.ops import transform
 
 from opera_disp_tms.frames import Frame, intersect
 from opera_disp_tms.s3_xarray import get_opera_disp_granule_metadata
-from opera_disp_tms.search import Granule, find_california_granules_for_frame
+from opera_disp_tms.search import Granule, find_granules_for_frame
 from opera_disp_tms.utils import validate_bbox
 
 
@@ -234,7 +234,7 @@ def create_metadata_tile(bbox: tuple[int, int, int, int], frames: Iterable[Frame
     create_empty_frame_tile(bbox, tile_path)
     frame_metadata = {}
     for frame in frames:
-        relevant_granules = find_california_granules_for_frame(frame.frame_id)
+        relevant_granules = find_granules_for_frame(frame.frame_id)
         if len(relevant_granules) == 0:
             warnings.warn(f'No granules found for frame {frame.frame_id}, this frame will not be added to the tile.')
         else:

--- a/src/opera_disp_tms/generate_sw_disp_tile.py
+++ b/src/opera_disp_tms/generate_sw_disp_tile.py
@@ -12,7 +12,7 @@ from rasterio.transform import Affine
 
 from opera_disp_tms import utils
 from opera_disp_tms.s3_xarray import open_opera_disp_granule, s3_xarray_dataset
-from opera_disp_tms.search import Granule, find_california_granules_for_frame
+from opera_disp_tms.search import Granule, find_granules_for_frame
 
 
 gdal.UseExceptions()
@@ -84,7 +84,7 @@ def find_needed_granules(
     """
     needed_granules = {}
     for frame_id in frame_ids:
-        granules_full_stack = find_california_granules_for_frame(frame_id)
+        granules_full_stack = find_granules_for_frame(frame_id)
         granules = [g for g in granules_full_stack if begin_date <= g.secondary_date <= end_date]
         if len(granules) < min_granules:
             warnings.warn(

--- a/src/opera_disp_tms/search.py
+++ b/src/opera_disp_tms/search.py
@@ -3,6 +3,9 @@ from datetime import datetime
 
 import requests
 
+# FIXME: Remove when updating to OPERA DISP data v0.9
+from opera_disp_tms.frames import get_orbit_pass
+
 
 CMR_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
@@ -32,7 +35,10 @@ class Granule:
 
         attributes = umm['umm']['AdditionalAttributes']
         frame_id = int(next(att['Values'][0] for att in attributes if att['Name'] == 'FRAME_ID'))
-        orbit_pass = next(att['Values'][0] for att in attributes if att['Name'] == 'ASCENDING_DESCENDING')
+
+        # FIXME: Use when updating to OPERA DISP data v0.9
+        # orbit_pass = next(att['Values'][0] for att in attributes if att['Name'] == 'ASCENDING_DESCENDING')
+        orbit_pass = get_orbit_pass(frame_id)
 
         urls = umm['umm']['RelatedUrls']
         url = next(url['URL'] for url in urls if url['Type'] == 'GET DATA')
@@ -71,10 +77,7 @@ def get_cmr_metadata(
     """
     cmr_parameters = {
         'short_name': 'OPERA_L3_DISP-S1_PROVISIONAL_V0',
-        'attribute[]': [
-            f'int,FRAME_ID,{frame_id}',
-            f'float,PRODUCT_VERSION,{version},'
-        ],
+        'attribute[]': [f'int,FRAME_ID,{frame_id}', f'float,PRODUCT_VERSION,{version},'],
         'page_size': 2000,
     }
     headers = {}

--- a/src/opera_disp_tms/search.py
+++ b/src/opera_disp_tms/search.py
@@ -65,7 +65,7 @@ class Granule:
 
 def get_cmr_metadata(
     frame_id: int,
-    version: str = '0.9',
+    version: str = '0.7',
     cmr_endpoint='https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json',
 ) -> list[dict]:
     """Find all OPERA L3 DISP S1 granules for a specific frame ID and minimum product version

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -48,3 +48,8 @@ def test_build_query():
     query, params = frames.build_query(bbox, is_land=False)
     assert ' AND is_land = ?' in query.splitlines()[-1]
     assert params == [wkt_str, 0]
+
+
+def test_get_orbit_pass():
+    assert frames.get_orbit_pass(9154) == 'ASCENDING'
+    assert frames.get_orbit_pass(3325) == 'DESCENDING'

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -50,6 +50,7 @@ def test_build_query():
     assert params == [wkt_str, 0]
 
 
+# FIXME: Remove when updating to OPERA DISP data v0.9
 def test_get_orbit_pass():
     assert frames.get_orbit_pass(9154) == 'ASCENDING'
     assert frames.get_orbit_pass(3325) == 'DESCENDING'

--- a/tests/test_generate_sw_disp_tile.py
+++ b/tests/test_generate_sw_disp_tile.py
@@ -61,7 +61,7 @@ def test_find_needed_granules():
         GranuleStub(frame_id=1, secondary_date=datetime(2021, 1, 3)),
     ]
 
-    fn_name = 'opera_disp_tms.generate_sw_disp_tile.find_california_granules_for_frame'
+    fn_name = 'opera_disp_tms.generate_sw_disp_tile.find_granules_for_frame'
     with mock.patch(fn_name, return_value=granules):
         needed_granules = sw.find_needed_granules([1], datetime(2021, 1, 1), datetime(2021, 1, 3), strategy='max')
         assert len(needed_granules[1]) == 1

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -39,7 +39,9 @@ def test_from_umm():
     assert Granule.from_umm(umm) == Granule(
         scene_name='mock-scene-name',
         frame_id=9154,
-        orbit_pass='DESCENDING',
+        # FIXME: Use when updating to OPERA DISP data v0.9
+        # orbit_pass='DESCENDING',
+        orbit_pass='ASCENDING',
         url='mock-url',
         s3_uri='mock-s3-uri',
         reference_date=datetime(2019, 10, 6, 0, 26, 42),

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -19,7 +19,11 @@ def test_from_umm():
                 {
                     "Name": "FRAME_ID",
                     "Values": ["8882"]
-                }
+                },
+                {
+                    "Name": "ASCENDING_DESCENDING",
+                    "Values": ["ASCENDING"]
+                },
             ],
             "RelatedUrls": [
                 {
@@ -39,23 +43,6 @@ def test_from_umm():
     assert Granule.from_umm(umm) == Granule(
         scene_name='mock-scene-name',
         frame_id=8882,
-        orbit_pass='UNKNOWN',
-        url='mock-url',
-        s3_uri='mock-s3-uri',
-        reference_date=datetime(2019, 10, 6, 0, 26, 42),
-        secondary_date=datetime(2020, 9, 30, 0, 26, 48),
-        creation_date=datetime(2024, 10, 29, 21, 36, 46),
-    )
-
-    umm['umm']['AdditionalAttributes'] = [
-        {
-            "Name": "FRAME_ID",
-            "Values": ["9154"]
-        }
-    ]
-    assert Granule.from_umm(umm) == Granule(
-        scene_name='mock-scene-name',
-        frame_id=9154,
         orbit_pass='ASCENDING',
         url='mock-url',
         s3_uri='mock-s3-uri',
@@ -67,12 +54,16 @@ def test_from_umm():
     umm['umm']['AdditionalAttributes'] = [
         {
             "Name": "FRAME_ID",
-            "Values": ["3325"]
-        }
+            "Values": ["9154"]
+        },
+        {
+            "Name": "ASCENDING_DESCENDING",
+            "Values": ["DESCENDING"]
+        },
     ]
     assert Granule.from_umm(umm) == Granule(
         scene_name='mock-scene-name',
-        frame_id=3325,
+        frame_id=9154,
         orbit_pass='DESCENDING',
         url='mock-url',
         s3_uri='mock-s3-uri',


### PR DESCRIPTION
A new v0.9 data delivery is expected in CMR UAT later this week. This PR updates search.py to query for any v9.0+ granules in UAT, rather than only California-specific v0.7 granules.

Orbit pass direction is available via the `ASCENDING_DESCENDING` additional attribute in CMR UAT for granules ingested after 2024-12-09, eliminating the need for a hardcoded list of ascending and descending frames.