### PR TITLE
search new v0.9 data in CMR, and take orbit direction from cmr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 * Revised `search.py` to query all v0.9+ granules in CMR UAT, rather than California-specific v0.7 granules
+* Accommodate `FRAME_ID` CMR attribute being renamed to `FRAME_NUMBER`
 * The [`static-analysis`](.github/workflows/static-analysis.yml) Github Actions workflow now uses `ruff` rather than `flake8` for linting.
 
 ## [0.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.1]
+## [0.5.0]
 ### Added
 * Granule orbit directions are now taken from the ASCENDING_DESCENDING attribute in CMR, rather than the frame database
 
 ### Changed
 * Revised `search.py` to query all v0.9+ granules in CMR UAT, rather than California-specific v0.7 granules
 * Accommodate `FRAME_ID` CMR attribute being renamed to `FRAME_NUMBER`
+
+## [0.4.1]
+### Changed
 * The [`static-analysis`](.github/workflows/static-analysis.yml) Github Actions workflow now uses `ruff` rather than `flake8` for linting.
 
 ## [0.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.1]
 ### Added
-* `get_orbit_pass` for using OPERA frame DB for getting a frame's orbit direction
+* Granule orbit directions are now taken from the ASCENDING_DESCENDING attribute in CMR, rather than the frame database
 
 ### Changed
-* Revised `search.py` to query all v0.7+ granules in CMR UAT, rather than California-specific v0.7 granules
+* Revised `search.py` to query all v0.9+ granules in CMR UAT, rather than California-specific v0.7 granules
 * The [`static-analysis`](.github/workflows/static-analysis.yml) Github Actions workflow now uses `ruff` rather than `flake8` for linting.
 
 ## [0.4.0]

--- a/src/opera_disp_tms/frames.py
+++ b/src/opera_disp_tms/frames.py
@@ -170,32 +170,3 @@ def intersect(
 
     intersecting_frames = [Frame.from_row(row) for row in rows]
     return intersecting_frames
-
-
-# FIXME: Remove when updating to OPERA DISP data v0.9
-def get_orbit_pass(frame_id: int) -> str:
-    """Get the orbit pass for an OPERA frame
-
-    Args:
-        frame_id: OPERA frame ID to get orbit pass for
-
-    Returns:
-        "ASCENDING" or "DESCENDING"
-    """
-    download_frame_db()
-    query = (
-        'SELECT fid as frame_id, epsg, relative_orbit_number, orbit_pass, '
-        '       is_land, is_north_america, ASText(GeomFromGPB(geom)) AS wkt '
-        'FROM frames '
-        'WHERE fid = ?'
-    )
-    with sqlite3.connect(DB_PATH) as con:
-        con.enable_load_extension(True)
-        con.load_extension('mod_spatialite')
-        cursor = con.cursor()
-        cursor.execute(query, [int(frame_id)])
-        rows = cursor.fetchall()
-
-    assert len(rows) == 1
-    frame = Frame.from_row(rows[0])
-    return frame.orbit_pass

--- a/src/opera_disp_tms/search.py
+++ b/src/opera_disp_tms/search.py
@@ -3,9 +3,6 @@ from datetime import datetime
 
 import requests
 
-# FIXME: Remove when updating to OPERA DISP data v0.9
-from opera_disp_tms.frames import get_orbit_pass
-
 
 CMR_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
@@ -35,10 +32,7 @@ class Granule:
 
         attributes = umm['umm']['AdditionalAttributes']
         frame_id = int(next(att['Values'][0] for att in attributes if att['Name'] == 'FRAME_ID'))
-
-        # FIXME: Use when updating to OPERA DISP data v0.9
-        # orbit_pass = next(att['Values'][0] for att in attributes if att['Name'] == 'ASCENDING_DESCENDING')
-        orbit_pass = get_orbit_pass(frame_id)
+        orbit_pass = next(att['Values'][0] for att in attributes if att['Name'] == 'ASCENDING_DESCENDING')
 
         urls = umm['umm']['RelatedUrls']
         url = next(url['URL'] for url in urls if url['Type'] == 'GET DATA')
@@ -65,7 +59,7 @@ class Granule:
 
 def get_cmr_metadata(
     frame_id: int,
-    version: str = '0.7',
+    version: str = '0.9',
     cmr_endpoint='https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json',
 ) -> list[dict]:
     """Find all OPERA L3 DISP S1 granules for a specific frame ID and minimum product version
@@ -76,7 +70,7 @@ def get_cmr_metadata(
         cmr_endpoint: The endpoint to query for granules.
     """
     cmr_parameters = {
-        'short_name': 'OPERA_L3_DISP-S1_PROVISIONAL_V0',
+        'short_name': 'OPERA_L3_DISP-S1_V1',
         'attribute[]': [f'int,FRAME_ID,{frame_id}', f'float,PRODUCT_VERSION,{version},'],
         'page_size': 2000,
     }

--- a/src/opera_disp_tms/search.py
+++ b/src/opera_disp_tms/search.py
@@ -31,7 +31,7 @@ class Granule:
         scene_name = umm['meta']['native-id']
 
         attributes = umm['umm']['AdditionalAttributes']
-        frame_id = int(next(att['Values'][0] for att in attributes if att['Name'] == 'FRAME_ID'))
+        frame_id = int(next(att['Values'][0] for att in attributes if att['Name'] == 'FRAME_NUMBER'))
         orbit_pass = next(att['Values'][0] for att in attributes if att['Name'] == 'ASCENDING_DESCENDING')
 
         urls = umm['umm']['RelatedUrls']
@@ -71,7 +71,7 @@ def get_cmr_metadata(
     """
     cmr_parameters = {
         'short_name': 'OPERA_L3_DISP-S1_V1',
-        'attribute[]': [f'int,FRAME_ID,{frame_id}', f'float,PRODUCT_VERSION,{version},'],
+        'attribute[]': [f'int,FRAME_NUMBER,{frame_id}', f'float,PRODUCT_VERSION,{version},'],
         'page_size': 2000,
     }
     headers = {}

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -48,9 +48,3 @@ def test_build_query():
     query, params = frames.build_query(bbox, is_land=False)
     assert ' AND is_land = ?' in query.splitlines()[-1]
     assert params == [wkt_str, 0]
-
-
-# FIXME: Remove when updating to OPERA DISP data v0.9
-def test_get_orbit_pass():
-    assert frames.get_orbit_pass(9154) == 'ASCENDING'
-    assert frames.get_orbit_pass(3325) == 'DESCENDING'

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -11,7 +11,7 @@ def test_from_umm():
                 'RangeDateTime': {'BeginningDateTime': '2019-10-06T00:26:42Z', 'EndingDateTime': '2020-09-30T00:26:48Z'}
             },
             'AdditionalAttributes': [
-                {'Name': 'FRAME_ID', 'Values': ['8882']},
+                {'Name': 'FRAME_NUMBER', 'Values': ['8882']},
                 {'Name': 'ASCENDING_DESCENDING', 'Values': ['ASCENDING']},
             ],
             'RelatedUrls': [
@@ -33,7 +33,7 @@ def test_from_umm():
     )
 
     umm['umm']['AdditionalAttributes'] = [
-        {'Name': 'FRAME_ID', 'Values': ['9154']},
+        {'Name': 'FRAME_NUMBER', 'Values': ['9154']},
         {'Name': 'ASCENDING_DESCENDING', 'Values': ['DESCENDING']},
     ]
     assert Granule.from_umm(umm) == Granule(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -39,9 +39,7 @@ def test_from_umm():
     assert Granule.from_umm(umm) == Granule(
         scene_name='mock-scene-name',
         frame_id=9154,
-        # FIXME: Use when updating to OPERA DISP data v0.9
-        # orbit_pass='DESCENDING',
-        orbit_pass='ASCENDING',
+        orbit_pass='DESCENDING',
         url='mock-url',
         s3_uri='mock-s3-uri',
         reference_date=datetime(2019, 10, 6, 0, 26, 42),


### PR DESCRIPTION
The old <=v0.7 data available in CMR UAT was under the `OPERA_L3_DISP-S1_PROVISIONAL_V0` collection

The new >=v0.8 data in CMR UAT is under the `OPERA_L3_DISP-S1_V1` collection. I've confirmed all the granules in this collection now populate the `ASCENDING_DESCENDING` additional attribute, eliminating the need to query flight direction from the frame database. I've confirmed all v0.9 granules in the new collection have the `FRAME_NUMBER` attribute, rather than the previously named `FRAME_ID` attribute.