### PR TITLE
exclude nodata .pngs from tile map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ than creating measurement geotiffs for each 1x1 degree tile.
 * `create_measurement_geotiff` replaces both `generate_sw_disp_tile` and `generate_sw_vel_tile`. This script takes a
   measurement type, frame id, start date, and end date, computes the requested measurement value (displacement,
   secant_velocity, velocity) for the given frame and date range, and outputs a geotiff in EPSG:3857.
+* `create_tile_map.py` now excludes entirely NoData .pngs from the result tile set.
 
 ### Removed
 * `generate_metadata_tile.py` has been removed, as creation of metadata tiles is no longer necessary

--- a/src/opera_disp_tms/create_tile_map.py
+++ b/src/opera_disp_tms/create_tile_map.py
@@ -75,6 +75,7 @@ def create_tile_map(output_folder: str, input_rasters: list[str], scale_range: l
             'gdal2tiles',
             '--xyz',
             '--zoom=2-11',
+            '--exclude',
             f'--processes={multiprocessing.cpu_count()}',
             '--webviewer=openlayers',
             '--resampling=near',


### PR DESCRIPTION
Reduces the current UAT descending mosaic from 230,665 .pngs to 5,838 .pngs.