### PR TITLE
search cmr for v1.0+ products

### DIFF
--- a/src/opera_disp_tms/search.py
+++ b/src/opera_disp_tms/search.py
@@ -59,7 +59,7 @@ class Granule:
 
 def get_cmr_metadata(
     frame_id: int,
-    version: str = '0.9',
+    version: str = '1.0',
     cmr_endpoint='https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json',
 ) -> list[dict]:
     """Find all OPERA L3 DISP S1 granules for a specific frame ID and minimum product version


### PR DESCRIPTION
Wait to merge until a sufficient quantity of v1.0+ products are available in CMR UAT:

https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json?attribute[]=float,PRODUCT_VERSION,1.0,&short_name=OPERA_L3_DISP-S1_V1

Still need to add a changelog entry to either v0.7.0 or v0.7.1 depending on when this is ready for release.