### PR TITLE
update s3 stubs for integrity checks introduced in boto3==1.36.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,8 +17,7 @@ dependencies:
   - responses
   # For Running
   - gdal
-  # FIXME check if boto3 S3 stub functonality is fixed in the future
-  - boto3<1.36.0
+  - boto3>=1.36.0
   - h5py
   - h5netcdf
   - xarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
 ]
 dependencies = [
     "gdal",
-    "boto3",
+    "boto3>=1.36.0",
     "h5py",
     "s3fs",
     "h5netcdf",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ def test_upload_file_to_s3(tmp_path, s3_stubber):
         'Bucket': 'myBucket',
         'Key': 'myPrefix/myObject.png',
         'ContentType': 'image/png',
+        'ChecksumAlgorithm': 'CRC32',
     }
     tag_params = {
         'Bucket': 'myBucket',


### PR DESCRIPTION
Starting with v1.36.0, boto3 now computes checksums for any get/put call and includes them in the call to the underlying API:  https://github.com/boto/boto3/issues/4392

In this case, we're testing a `put_object` call. Our stub for the underlying `PutObject` API call needs to include the `ChecksumAlgorithm` parameter now being included by boto3.