### PR TITLE
use resampling=med in create_tile_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2]
+
+### Changed
+* `create_tile_map` now uses median resampling instead of nearest neighbor resampling when building the TMS mosaic.
+  Significantly fewer NoData pixels are shown when zoomed out; more NoData pixels becoming visible when zooming in.
+
 ## [0.8.1]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 * `create_tile_map` now uses median resampling instead of nearest neighbor resampling when building the TMS mosaic.
-  Significantly fewer NoData pixels are shown when zoomed out; more NoData pixels becoming visible when zooming in.
+  Significantly fewer NoData pixels are shown when zoomed out; NoData pixels gradually appear when zooming in.
 
 ## [0.8.1]
 

--- a/src/opera_disp_tms/create_tile_map.py
+++ b/src/opera_disp_tms/create_tile_map.py
@@ -80,7 +80,7 @@ def create_tile_map(measurement_type: str, input_rasters: list[Path]) -> Path:
             '--zoom=2-11',
             f'--processes={multiprocessing.cpu_count()}',
             '--webviewer=openlayers',
-            '--resampling=near',
+            '--resampling=med',
             byte_vrt.name,
             str(output_dir),
         ]


### PR DESCRIPTION
Small example using the old `nearest` resampling method: https://hyp3-opera-disp-sandbox-contentbucket-ibxz8lcpdo59.s3.us-west-2.amazonaws.com/be9cae0e-7aa9-43bc-99a3-4787aebf5b74/tms_nearest/openlayers.html


Same example using the new `median` resampling method: https://hyp3-opera-disp-sandbox-contentbucket-ibxz8lcpdo59.s3.us-west-2.amazonaws.com/be9cae0e-7aa9-43bc-99a3-4787aebf5b74/tms/openlayers.html