### PR TITLE
implement 2d test case for replace_nans_with_zeros

### DIFF
--- a/src/opera_disp_tms/prep_stack.py
+++ b/src/opera_disp_tms/prep_stack.py
@@ -94,11 +94,11 @@ def replace_nans_with_zeros(granule_xrs: list[xr.DataArray], minimum_valid_data_
     valid_data_percent = sum(~np.isnan(granule_xr) for granule_xr in granule_xrs) / len(granule_xrs)
     for granule_xr in granule_xrs:
         values_to_update = np.logical_and(valid_data_percent >= minimum_valid_data_percent, np.isnan(granule_xr))
-        granule_xr[values_to_update] = 0.0
+        granule_xr.data[values_to_update] = 0.0
 
 
 def check_connected_network(granule_xrs: list[xr.DataArray]) -> None:
-    """Check that cumulative displacement can reconstructed using given granule set.
+    """Check that cumulative displacement can be reconstructed using given granule set.
 
     Args:
         granule_xrs: A list of granule xarray DataArrays

--- a/tests/test_prep_stack.py
+++ b/tests/test_prep_stack.py
@@ -80,20 +80,38 @@ def test_restrict_to_spanning_set():
 
 def test_replace_nans_with_zeros():
     xrs = [
-        xr.DataArray([1.0, 0.0, 1.0]),
-        xr.DataArray([5.0, np.nan, np.nan]),
-        xr.DataArray([-1.0, 0.0, np.nan]),
-        xr.DataArray([7.0, 0.0, 1.0]),
-        xr.DataArray([-3.0, 1.0, 1.0]),
+        xr.DataArray([[1.0, 0.0], [1.0, 0.0]]),
+        xr.DataArray([[5.0, np.nan], [np.nan, 0.0]]),
+        xr.DataArray([[-1.0, 0.0], [np.nan, np.nan]]),
+        xr.DataArray([[7.0, 0.0], [1.0, np.nan]]),
+        xr.DataArray([[-3.0, 1.0], [1.0, np.nan]]),
     ]
     expected = [
-        xr.DataArray([1.0, 0.0, 1.0]),
-        xr.DataArray([5.0, 0.0, np.nan]),
-        xr.DataArray([-1.0, 0.0, np.nan]),
-        xr.DataArray([7.0, 0.0, 1.0]),
-        xr.DataArray([-3.0, 1.0, 1.0]),
+        xr.DataArray([[1.0, 0.0], [1.0, 0.0]]),
+        xr.DataArray([[5.0, 0.0], [np.nan, 0.0]]),
+        xr.DataArray([[-1.0, 0.0], [np.nan, np.nan]]),
+        xr.DataArray([[7.0, 0.0], [1.0, np.nan]]),
+        xr.DataArray([[-3.0, 1.0], [1.0, np.nan]]),
     ]
     prep_stack.replace_nans_with_zeros(xrs, minimum_valid_data_percent=0.8)
+    assert all(a.identical(b) for a, b in zip(xrs, expected))
+
+
+    xrs = [
+        xr.DataArray([[1.0, 0.0], [1.0, 0.0]]),
+        xr.DataArray([[5.0, np.nan], [np.nan, 0.0]]),
+        xr.DataArray([[-1.0, 0.0], [np.nan, np.nan]]),
+        xr.DataArray([[7.0, 0.0], [1.0, np.nan]]),
+        xr.DataArray([[-3.0, 1.0], [1.0, np.nan]]),
+    ]
+    expected = [
+        xr.DataArray([[1.0, 0.0], [1.0, 0.0]]),
+        xr.DataArray([[5.0, 0.0], [0.0, 0.0]]),
+        xr.DataArray([[-1.0, 0.0], [0.0, np.nan]]),
+        xr.DataArray([[7.0, 0.0], [1.0, np.nan]]),
+        xr.DataArray([[-3.0, 1.0], [1.0, np.nan]]),
+    ]
+    prep_stack.replace_nans_with_zeros(xrs, minimum_valid_data_percent=0.6)
     assert all(a.identical(b) for a, b in zip(xrs, expected))
 
 

--- a/tests/test_prep_stack.py
+++ b/tests/test_prep_stack.py
@@ -97,7 +97,6 @@ def test_replace_nans_with_zeros():
     prep_stack.replace_nans_with_zeros(xrs, minimum_valid_data_percent=0.8)
     assert all(a.identical(b) for a, b in zip(xrs, expected))
 
-
     xrs = [
         xr.DataArray([[1.0, 0.0], [1.0, 0.0]]),
         xr.DataArray([[5.0, np.nan], [np.nan, 0.0]]),

--- a/tests/test_prep_stack.py
+++ b/tests/test_prep_stack.py
@@ -86,6 +86,7 @@ def test_replace_nans_with_zeros():
         xr.DataArray([[7.0, 0.0], [1.0, np.nan]]),
         xr.DataArray([[-3.0, 1.0], [1.0, np.nan]]),
     ]
+
     expected = [
         xr.DataArray([[1.0, 0.0], [1.0, 0.0]]),
         xr.DataArray([[5.0, 0.0], [np.nan, 0.0]]),


### PR DESCRIPTION
Working as expected now, here's the output of `create_measurement_geotiff 11115 velocity 20150101 20260101` (20 granules) from `main` and `fix-2d`:

```
Found 20 granules for frame 11115 between 2015-01-01 00:00:00 and 2026-01-01 00:00:00
  OPERA_L3_DISP-S1_IW_F11115_VV_20160810T140735Z_20170419T140734Z_v1.0_20250408T164117Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20170419T140734Z_20171121T140742Z_v1.0_20250408T223744Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20171121T140742Z_20180601T140743Z_v1.0_20250409T045924Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20180601T140743Z_20181128T140749Z_v1.0_20250409T113753Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20181128T140749Z_20190527T140749Z_v1.0_20250409T182208Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20190527T140749Z_20190930T140714Z_v1.0_20250410T012300Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20190930T140714Z_20191229T140754Z_v1.0_20250410T082339Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20191229T140754Z_20200403T140753Z_v1.0_20250410T152628Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20200403T140753Z_20200702T140715Z_v1.0_20250410T224553Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20200702T140715Z_20200930T140802Z_v1.0_20250411T052824Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20200930T140802Z_20201229T140718Z_v1.0_20250411T122626Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20201229T140718Z_20210329T140758Z_v1.0_20250411T191839Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20210329T140758Z_20210627T140721Z_v1.0_20250413T073103Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20210627T140721Z_20210925T140808Z_v1.0_20250414T220412Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20210925T140808Z_20211230T140806Z_v1.0_20250415T205742Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20211230T140806Z_20220628T140809Z_v1.0_20250416T041110Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20220628T140809Z_20230106T140811Z_v1.0_20250416T105704Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20230106T140811Z_20230717T140815Z_v1.0_20250416T233555Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20230717T140815Z_20240125T140815Z_v1.0_20250417T071809Z
  OPERA_L3_DISP-S1_IW_F11115_VV_20240125T140815Z_20240723T140814Z_v1.0_20250417T141118Z
```

`main`:
![Screenshot from 2025-05-05 10-03-29](https://github.com/user-attachments/assets/e38efd5e-9fcb-41f8-9510-ce736a5587d9)

`fix-2d`:
![Screenshot from 2025-05-05 10-03-33](https://github.com/user-attachments/assets/ccb9db40-856f-45cf-8f10-e5a7f658f55e)
