### PR TITLE
prevent accidentally casting data to float64 in create_measurement_geotiff

### DIFF
--- a/src/opera_disp_tms/create_measurement_geotiff.py
+++ b/src/opera_disp_tms/create_measurement_geotiff.py
@@ -72,7 +72,7 @@ def parallel_linear_regression(x: np.ndarray, y: np.ndarray) -> np.ndarray:
         y: A 3D array of dependent variables with dimensions (time, y, x)
     """
     n, m, p = y.shape
-    slope_array = np.zeros((m, p))
+    slope_array = np.zeros(shape=(m, p), dtype=y.dtype)
     for i in prange(m):
         for j in prange(p):
             slope, intercept = linear_regression_leastsquares(x, y[:, i, j].copy())
@@ -110,7 +110,7 @@ def compute_measurement(measurement_type: str, stack: list[xr.DataArray]) -> xr.
     cube = cube.assign_coords(years_since_start=years_since_start)
 
     # Using xarray's polyfit is 13x slower when running a regression for 44 time steps
-    slope = parallel_linear_regression(cube.years_since_start.data.astype('float64'), cube.data.astype('float64'))
+    slope = parallel_linear_regression(cube.years_since_start.data, cube.data)
 
     new_coords = {'x': cube.x, 'y': cube.y, 'spatial_ref': cube.spatial_ref}
     slope_da = xr.DataArray(slope, dims=('y', 'x'), coords=new_coords, attrs=stack[-1].attrs)

--- a/src/opera_disp_tms/prep_stack.py
+++ b/src/opera_disp_tms/prep_stack.py
@@ -123,7 +123,7 @@ def align_to_common_reference_date(granule_xrs: list[xr.DataArray], start_date: 
     if start_date <= granule_xrs[0].reference_date:
         zero_xr = granule_xrs[0].copy()
         zero_xr.attrs['secondary_date'] = zero_xr.attrs['reference_date']
-        zero_xr.data = np.zeros(zero_xr.shape)
+        zero_xr.data = np.zeros_like(zero_xr)
         granule_xrs.insert(0, zero_xr)
 
     previous_granule_xr = granule_xrs[0]

--- a/tests/test_create_measurement_geotiff.py
+++ b/tests/test_create_measurement_geotiff.py
@@ -60,15 +60,17 @@ def test_linear_regression_leastsquares():
 
 
 def test_parallel_linear_regression():
-    y_col = np.arange(3, dtype='float64')
-    y = np.ones((3, 5, 5), dtype='float64') * -1
-    indexes = np.arange(5)
-    for i in indexes:
-        for j in indexes:
-            y[:, i, j] = y_col
-    x = np.arange(3, dtype='float64')
-    slope = geo.parallel_linear_regression(x, y)
-    assert np.all(np.isclose(slope, 1.0, atol=1e-6))
+    for dtype in (np.float32, np.float64, np.int8):
+        y_col = np.arange(3, dtype=dtype)
+        y = np.ones((3, 5, 5), dtype=dtype) * -1
+        indexes = np.arange(5)
+        for i in indexes:
+            for j in indexes:
+                y[:, i, j] = y_col
+        x = np.arange(3, dtype=dtype)
+        slope = geo.parallel_linear_regression(x, y)
+        assert np.all(np.isclose(slope, 1.0, atol=1e-6))
+        assert slope.dtype == dtype
 
 
 def test_compute_measurement():

--- a/tests/test_prep_stack.py
+++ b/tests/test_prep_stack.py
@@ -116,14 +116,14 @@ def test_replace_nans_with_zeros():
 
 
 def test_align_to_common_reference_date():
-    def create_data_array(data, ref_date, sec_date):
+    def create_data_array(data, ref_date, sec_date, dtype=np.float64):
         coords = {'x': [1, 2]}
         da = xr.DataArray(
             data=data,
             attrs={'reference_date': ref_date, 'secondary_date': sec_date, 'frame_id': 1},
             coords=coords,
         )
-        return da
+        return da.astype(dtype)
 
     xrs = [
         create_data_array([1.0, 0.0], datetime(1, 1, 1), datetime(1, 1, 2)),
@@ -142,24 +142,26 @@ def test_align_to_common_reference_date():
     ]
     prep_stack.align_to_common_reference_date(xrs, start_date=datetime(1, 1, 1))
     assert all(a.identical(b) for a, b in zip(xrs, expected))
+    assert all(xr.dtype == np.float64 for xr in xrs)
 
     xrs = [
-        create_data_array([1.0, 0.0], datetime(1, 1, 1), datetime(1, 1, 2)),
-        create_data_array([5.0, 0.0], datetime(1, 1, 1), datetime(1, 1, 3)),
-        create_data_array([-1.0, 0.0], datetime(1, 1, 3), datetime(1, 1, 4)),
-        create_data_array([7.0, 0.0], datetime(1, 1, 3), datetime(1, 1, 5)),
-        create_data_array([-3.0, 1.0], datetime(1, 1, 5), datetime(1, 1, 6)),
+        create_data_array([1.0, 0.0], datetime(1, 1, 1), datetime(1, 1, 2), np.float32),
+        create_data_array([5.0, 0.0], datetime(1, 1, 1), datetime(1, 1, 3), np.float32),
+        create_data_array([-1.0, 0.0], datetime(1, 1, 3), datetime(1, 1, 4), np.float32),
+        create_data_array([7.0, 0.0], datetime(1, 1, 3), datetime(1, 1, 5), np.float32),
+        create_data_array([-3.0, 1.0], datetime(1, 1, 5), datetime(1, 1, 6), np.float32),
     ]
     expected = [
-        create_data_array([0.0, 0.0], datetime(1, 1, 2), datetime(1, 1, 2)),
-        create_data_array([4.0, 0.0], datetime(1, 1, 2), datetime(1, 1, 3)),
-        create_data_array([3.0, 0.0], datetime(1, 1, 2), datetime(1, 1, 4)),
-        create_data_array([11.0, 0.0], datetime(1, 1, 2), datetime(1, 1, 5)),
-        create_data_array([8.0, 1.0], datetime(1, 1, 2), datetime(1, 1, 6)),
+        create_data_array([0.0, 0.0], datetime(1, 1, 2), datetime(1, 1, 2), np.float32),
+        create_data_array([4.0, 0.0], datetime(1, 1, 2), datetime(1, 1, 3), np.float32),
+        create_data_array([3.0, 0.0], datetime(1, 1, 2), datetime(1, 1, 4), np.float32),
+        create_data_array([11.0, 0.0], datetime(1, 1, 2), datetime(1, 1, 5), np.float32),
+        create_data_array([8.0, 1.0], datetime(1, 1, 2), datetime(1, 1, 6), np.float32),
     ]
 
     prep_stack.align_to_common_reference_date(xrs, start_date=datetime(1, 1, 1, 12))
     assert all(a.identical(b) for a, b in zip(xrs, expected))
+    assert all(xr.dtype==np.float32 for xr in xrs)
 
     xrs = [create_data_array([20.0, -5.0], datetime(1, 1, 1), datetime(1, 1, 2))]
     expected = [

--- a/tests/test_prep_stack.py
+++ b/tests/test_prep_stack.py
@@ -161,7 +161,7 @@ def test_align_to_common_reference_date():
 
     prep_stack.align_to_common_reference_date(xrs, start_date=datetime(1, 1, 1, 12))
     assert all(a.identical(b) for a, b in zip(xrs, expected))
-    assert all(xr.dtype==np.float32 for xr in xrs)
+    assert all(xr.dtype == np.float32 for xr in xrs)
 
     xrs = [create_data_array([20.0, -5.0], datetime(1, 1, 1), datetime(1, 1, 2))]
     expected = [


### PR DESCRIPTION
The short_wavelength_displacement data we're working with is `float32`. [np.zeros]() defaults to float64, which was unnecessarily casting data from float32 to float64 in `create_measurement_geotiff.parallel_linear_regression` and `prep_stack.align_to_common_reference_date`. With these changes those functions now return data with the same data type as the input data.

I've confirmed `create_measurement_geotiff 18648 velocity 20140101 20300101` creates visually identical output before and after this change, and the data type of the post-change geotiff is `Float32` instead of `Float64`, cutting the output size in half.