### PR TITLE
compress and tile output of create_measurement_geotiff

### DIFF
--- a/src/opera_disp_tms/create_measurement_geotiff.py
+++ b/src/opera_disp_tms/create_measurement_geotiff.py
@@ -133,7 +133,7 @@ def create_measurement_geotiff(measurement_type: str, frame_id: int, begin_date:
 
     product_name = create_geotiff_name(measurement_type, frame_id, begin_date, end_date)
     product_path = Path.cwd() / product_name
-    data.rio.to_raster(product_path.name)
+    data.rio.to_raster(product_path.name, compress='DEFLATE', tiled=True)
     return product_path
 
 


### PR DESCRIPTION
Reduces the size of individual measurement geotiffs by about half, which is important now that the global mosaics include 500-700 geotiffs each.