### PR TITLE
do not create empty .pngs for areas with no data in create_tile_map.py

### DIFF
--- a/src/opera_disp_tms/create_tile_map.py
+++ b/src/opera_disp_tms/create_tile_map.py
@@ -81,6 +81,7 @@ def create_tile_map(measurement_type: str, input_rasters: list[Path]) -> Path:
             f'--processes={multiprocessing.cpu_count()}',
             '--webviewer=openlayers',
             '--resampling=med',
+            '--exclude',
             byte_vrt.name,
             str(output_dir),
         ]


### PR DESCRIPTION
per https://gdal.org/en/stable/programs/gdal2tiles.html#cmdoption-gdal2tiles-x :
> #### -x, --exclude
> Exclude transparent tiles from result tileset.

Eliminates generation of millions of empty .pngs now that the mosaics include a smattering of data in the eastern hemisphere in addition to the bulk of the data in North America.